### PR TITLE
First iteration of NFT minting contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .metals/
 .bloop/
 .vscode/
+.idea/
+null/
 
 project/target/
 project/project/

--- a/config.json
+++ b/config.json
@@ -9,9 +9,12 @@
             "password": "Wallet Password",
             "mnemonicPassword": "Mnemonic Password"
         },
-        "networkType": "MAINNET"
+        "networkType": "TESTNET"
     },
     "parameters": {
-        "addressIndex": 0
+        "addressIndex": 0,
+        "mintingContractAddress": "2MqbjEo9wnqk3D9mzDnfWaZvunYxFfJ1EdxxvLM8sKrznndwTZrMvmjmERaLUr6qSBtMy3VYLfwH7gWrceh5egDfzanJKn2nwkpXDPWGryz3k8ZHT5v",
+        "nftMintRequestBoxId": "9c30255620a76b252a790bc1c4d0e52167c88e21d42402af83246b4014b2e095",
+        "nftReceiverAddress": "3WwM8LKw18msCLqzEaGNAaRgS4FqFQka1vsUCWjNtvdM9UTGSAuy"
     }
 }

--- a/src/main/scala/GenerateMintContractAddress/GenerateMintContractAddress.scala
+++ b/src/main/scala/GenerateMintContractAddress/GenerateMintContractAddress.scala
@@ -1,0 +1,90 @@
+package GenerateMintContractAddress
+
+import org.ergoplatform.appkit._
+import org.ergoplatform.appkit.config.{ErgoNodeConfig, ErgoToolConfig}
+
+object GenerateMintContractAddress {
+  def generateMintingContract(configFileName: String): String = {
+    // Node configuration values
+    val conf: ErgoToolConfig = ErgoToolConfig.load(configFileName)
+    val nodeConf: ErgoNodeConfig = conf.getNode
+    val explorerUrl: String = RestApiErgoClient.getDefaultExplorerUrl(NetworkType.TESTNET)
+
+    // Fetch parameters from config
+    val addressIndex: Int = conf.getParameters.get("addressIndex").toInt
+
+    // Create ErgoClient instance (represents a connection to node)
+    var ergoClient: ErgoClient = RestApiErgoClient.create(nodeConf, explorerUrl)
+
+    // Execute transaction
+    val txJson: String = ergoClient.execute((ctx: BlockchainContext) => {
+
+      // Initialize prover (signs the transaction)
+      val senderProver: ErgoProver = ctx.newProverBuilder
+        .withMnemonic(
+          SecretString.create(nodeConf.getWallet.getMnemonic),
+          SecretString.create(nodeConf.getWallet.getPassword)
+        )
+        .withEip3Secret(addressIndex)
+        .build()
+
+      // Get input (spending) boxes from node wallet
+      val wallet: ErgoWallet = ctx.getWallet
+      val amountToSend: Long = Parameters.MinChangeValue
+      val totalToSpend: Long = amountToSend + Parameters.MinFee
+      val boxes: java.util.Optional[java.util.List[InputBox]] = wallet.getUnspentBoxes(totalToSpend)
+      if (!boxes.isPresent)
+        throw new ErgoClientException(s"Not enough coins in the wallet to pay $totalToSpend", null)
+
+      // Define protection script
+      // The script expects an NFT to be issued, and that it be issued by a specific wallet
+      val mintingContract: String = s"""
+      {
+        val proposedTokenHasSameIdAsFirstTxInput = OUTPUTS(0).tokens(0)._1 == SELF.id
+        val proposedTokenIsNonFungible = OUTPUTS(0).tokens(0)._2 == 1
+        val proposedTokenIsValidNFT = proposedTokenHasSameIdAsFirstTxInput && proposedTokenIsNonFungible
+
+        sigmaProp(proposedTokenIsValidNFT && ergoNamesPk)
+      }
+      """.stripMargin
+
+      // Create unsigned tx builder
+      val txB: UnsignedTransactionBuilder = ctx.newTxBuilder
+
+      // Create output box
+      val ergoNamesPk: Address = Address.create(senderProver.getP2PKAddress.toString)
+      val newBox: OutBox = txB.outBoxBuilder
+        .value(amountToSend)
+        .contract(
+          ctx.compileContract(
+            ConstantsBuilder.create()
+              .item("ergoNamesPk", ergoNamesPk.getPublicKey)
+              .build(),
+            mintingContract))
+        .build()
+
+      // Create unsigned transaction
+      val tx: UnsignedTransaction = txB
+        .boxesToSpend(boxes.get)
+        .outputs(newBox)
+        .fee(Parameters.MinFee)
+        .sendChangeTo(senderProver.getP2PKAddress)
+        .build()
+
+      // Sign transaction with prover
+      val signed: SignedTransaction = senderProver.sign(tx)
+
+      // Submit transaction to node
+      val txId: String = ctx.sendTransaction(signed)
+
+      // Return transaction as JSON string
+      signed.toJson(true)
+    })
+    txJson
+  }
+
+  def main(args: Array[String]) : Unit = {
+    val txJson = generateMintingContract("config.json")
+    print(txJson)
+  }
+}

--- a/src/main/scala/GenerateMintContractAddress/GenerateMintContractAddress.scala
+++ b/src/main/scala/GenerateMintContractAddress/GenerateMintContractAddress.scala
@@ -4,7 +4,7 @@ import org.ergoplatform.appkit._
 import org.ergoplatform.appkit.config.{ErgoNodeConfig, ErgoToolConfig}
 
 object GenerateMintContractAddress {
-  def generateMintingContract(configFileName: String): String = {
+  def generateMintContractAddress(configFileName: String): String = {
     // Node configuration values
     val conf: ErgoToolConfig = ErgoToolConfig.load(configFileName)
     val nodeConf: ErgoNodeConfig = conf.getNode
@@ -84,7 +84,7 @@ object GenerateMintContractAddress {
   }
 
   def main(args: Array[String]) : Unit = {
-    val txJson = generateMintingContract("config.json")
+    val txJson = generateMintContractAddress("config.json")
     print(txJson)
   }
 }

--- a/src/main/scala/SpendBoxAtMintContractAddress/SpendBoxAtMintContractAddress.scala
+++ b/src/main/scala/SpendBoxAtMintContractAddress/SpendBoxAtMintContractAddress.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.appkit.impl.ErgoTreeContract
 import java.util.stream.Collectors
 
 object SpendBoxAtMintContractAddress {
-  def mintNftAtContractAddress(configFileName: String): String = {
+  def spendBoxAtContractAddress(configFileName: String): String = {
     // Node configuration values
     val conf: ErgoToolConfig = ErgoToolConfig.load(configFileName)
     val nodeConf: ErgoNodeConfig = conf.getNode
@@ -80,7 +80,7 @@ object SpendBoxAtMintContractAddress {
   }
 
   def main(args: Array[String]): Unit = {
-    val txJson = mintNftAtContractAddress("config.json")
+    val txJson = spendBoxAtContractAddress("config.json")
     print(txJson)
   }
 }

--- a/src/main/scala/SpendBoxAtMintContractAddress/SpendBoxAtMintContractAddress.scala
+++ b/src/main/scala/SpendBoxAtMintContractAddress/SpendBoxAtMintContractAddress.scala
@@ -1,0 +1,86 @@
+package SpendBoxAtMintContractAddress
+
+import org.ergoplatform.appkit.config.{ErgoNodeConfig, ErgoToolConfig}
+import org.ergoplatform.appkit._
+import org.ergoplatform.appkit.impl.ErgoTreeContract
+
+import java.util.stream.Collectors
+
+object SpendBoxAtMintContractAddress {
+  def mintNftAtContractAddress(configFileName: String): String = {
+    // Node configuration values
+    val conf: ErgoToolConfig = ErgoToolConfig.load(configFileName)
+    val nodeConf: ErgoNodeConfig = conf.getNode
+    val explorerUrl: String = RestApiErgoClient.getDefaultExplorerUrl(NetworkType.TESTNET)
+
+    // Fetch parameters from config
+    val nftReceiverAddress: Address = Address.create(conf.getParameters.get("nftReceiverAddress"))
+    val addressIndex: Int = conf.getParameters.get("addressIndex").toInt
+    val mintingContractAddress: String = conf.getParameters.get("mintingContractAddress")
+    val nftMintRequestBoxId: String = conf.getParameters.get("nftMintRequestBoxId")
+
+    // Create ErgoClient instance (represents a connection to node)
+    val ergoClient: ErgoClient = RestApiErgoClient.create(nodeConf, explorerUrl)
+
+    // Execute transaction
+    val txJson: String = ergoClient.execute((ctx: BlockchainContext) => {
+
+      // Initialize prover (signs the transaction)
+      val senderProver: ErgoProver = ctx.newProverBuilder
+        .withMnemonic(
+          SecretString.create(nodeConf.getWallet.getMnemonic),
+          SecretString.create(nodeConf.getWallet.getPassword)
+        )
+        .withEip3Secret(addressIndex)
+        .build()
+
+      // Get input (spending) boxes from minting contract address
+      val spendingAddress: Address = Address.create(mintingContractAddress)
+      val spendingBoxes: java.util.List[InputBox] = ctx.getUnspentBoxesFor(spendingAddress, 0, 20)
+        .stream()
+        .filter(_.getId == ErgoId.create(nftMintRequestBoxId))
+        .collect(Collectors.toList())
+
+      // Amount to retrieve from nft minting request box - this is essentially collecting payment for the mint
+      val amountToSend: Long = 25000000L - Parameters.MinFee
+
+      // Create unsigned tx builder
+      val txB: UnsignedTransactionBuilder = ctx.newTxBuilder
+
+      // Create output box
+      val proposedToken: ErgoToken = new ErgoToken(spendingBoxes.get(0).getId, 1)
+      val tokenName: String = "contract_issued_nft_test.erg"
+      val tokenDescription: String = "Early stage testing of token minting with contracts"
+      val tokenDecimals: Int = 0
+
+      val newBox: OutBox = txB.outBoxBuilder
+        .mintToken(proposedToken, tokenName, tokenDescription, tokenDecimals)
+        .value(amountToSend)
+        .contract(new ErgoTreeContract(nftReceiverAddress.getErgoAddress.script))
+        .build()
+
+      // Create unsigned transaction
+      val tx: UnsignedTransaction = txB
+        .boxesToSpend(spendingBoxes)
+        .outputs(newBox)
+        .fee(Parameters.MinFee)
+        .sendChangeTo(senderProver.getP2PKAddress)
+        .build()
+
+      // Sign transaction with prover
+      val signed: SignedTransaction = senderProver.sign(tx)
+
+      // Submit transaction to node
+      val txId: String = ctx.sendTransaction(signed)
+
+      // Return transaction as JSON string
+      signed.toJson(true)
+    })
+    txJson
+  }
+
+  def main(args: Array[String]): Unit = {
+    val txJson = mintNftAtContractAddress("config.json")
+    print(txJson)
+  }
+}


### PR DESCRIPTION
The first iteration of the minting contract expects that the tx issues an NFT (a token with amount of 1), and that the minting tx be signed by a given public key (in our case, it would be a dedicated ergo-names public key).

I managed to get this first contract iteration to compile. I then submitted a tx to the testnet network, and a script address was generated
https://testnet.ergoplatform.com/en/addresses/2MqbjEo9wnqk3D9mzDnfWaZvunYxFfJ1EdxxvLM8sKrznndwTZrMvmjmERaLUr6qSBtMy3VYLfwH7gWrceh5egDfzanJKn2nwkpXDPWGryz3k8ZHT5v

I then sent 0.0025 ERG to the script address. The expectation was that I should be able to spend the box with id `9c30255620a76b252a790bc1c4d0e52167c88e21d42402af83246b4014b2e095` at the script address _as long as I issued an NFT, and signed the tx with the same wallet I used to generate the contract address_.

That test succeeded
https://testnet.ergoplatform.com/en/transactions/216b917349e9d824cb86aff833237ac7c36c0511c4b778b8ba0491a5084e2c37

I was able to spend the box by fulfilling the described conditions, and sent the NFT to an address I specified in the tx building process (so not a contract constant).

Here's a rough outline of the process I followed:

1. Generated contract address
2. Simulated a user sending payment for an NFT by sending some ERG to the contract address.
3. Simulated processing of minting request by spending the box sent by user to the contract address.
4. Tx succeeded and NFT was issued to a user address _specified in the code_ (again, not the contract).

_Note: When compiled, this contract version produces a deterministic address, i.e., an address that will always be the same every time the contract is compiled._

This is good for illustrating that a contract can be used to enforce the issuing of an NFT, but it is not yet exactly what we want.
I've followed the "happy path" for this initial contract version. Some cases that should be tested before further changes are introduced to the contract are:
1. Try to issue a token with amount greater than 1 - tx should fail
2. Try to spend a box at the contract address from another wallet - tx should fail.
3. Try to spend a box at the contract address from another wallet while attempting to issue an NFT - tx should fail.

### Next steps
We need to be able not just to mint any NFT - but an NFT with the ergo name the user requested and paid for. Also we should be able to check the user paid the right amount (otherwise, tx should fail and user doesn't get charged), and send it to the user.

So far we have established that a user can send a box with ERG to the contract address, and that we can pick up those boxes and spend them to mint an NFT that gets sent back to an address we can specify.

**But the box the user sends currently does not contain any information about what the name of the token should be, how much it should cost, and who should receive the minted NFT.**

We should start thinking of a way to arrive at a contract version that can also:
- Verify the name of the issued token is the ergo name the user requested and paid for.
- Verify the payment amount is the expected one.
- Verify the NFT gets sent to the address the user used to pay.

All this without hard coding any values in code, and _while trying to maintain a deterministic contract address_. This part is key because we want to ideally use the contract address to verify NFT authenticity.