### PR TITLE
V2 minting contract

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,8 +13,12 @@
     },
     "parameters": {
         "addressIndex": 0,
-        "mintingContractAddress": "2MqbjEo9wnqk3D9mzDnfWaZvunYxFfJ1EdxxvLM8sKrznndwTZrMvmjmERaLUr6qSBtMy3VYLfwH7gWrceh5egDfzanJKn2nwkpXDPWGryz3k8ZHT5v",
-        "nftMintRequestBoxId": "9c30255620a76b252a790bc1c4d0e52167c88e21d42402af83246b4014b2e095",
-        "nftReceiverAddress": "3WwM8LKw18msCLqzEaGNAaRgS4FqFQka1vsUCWjNtvdM9UTGSAuy"
+        "mintingContractAddress": "DmM1th5FZComVTEk39h9QYmSjSR2xJpTFqr1QCx7Ln4eTLrBbSBn6KcwcVDMQ1aZ6Eosdwxejvx9abWDfSP8iuHznWhNVrf6j53SiPvfWSwEeLBXGC2ZWq2TKRNTUVDohGjrUmPVCCiaQtJJjiMCKrjooAbuSA6ifrUVhST5sbrPkGo59nbR",
+        "nftMintRequestBoxId": "b5ee170910fa48262f36a492abccb4a684d547a01a5bc66fa66a41a98a43faf8",
+        "nftReceiverAddress": "3WwM8LKw18msCLqzEaGNAaRgS4FqFQka1vsUCWjNtvdM9UTGSAuy",
+        "tokenName": "v2_contract_issued_nft_test.erg",
+        "tokenDescription": "Early stage testing of token minting with contracts",
+        "tokenDecimals": 0,
+        "paymentAmount": 2500000
     }
 }

--- a/src/main/scala/GenerateMintContractAddress/GenerateMintContractAddress.scala
+++ b/src/main/scala/GenerateMintContractAddress/GenerateMintContractAddress.scala
@@ -44,7 +44,25 @@ object GenerateMintContractAddress {
         val proposedTokenIsNonFungible = OUTPUTS(0).tokens(0)._2 == 1
         val proposedTokenIsValidNFT = proposedTokenHasSameIdAsFirstTxInput && proposedTokenIsNonFungible
 
-        sigmaProp(proposedTokenIsValidNFT && ergoNamesPk)
+        val expectedTokenName = INPUTS(0).R4[Coll[Byte]].get
+        val proposedTokenName = OUTPUTS(0).R4[Coll[Byte]].get
+        val tokenNameIsCorrect = expectedTokenName == proposedTokenName
+
+        val expectedPaymentAmount = INPUTS(0).R5[Long].get
+        val sentPaymentAmount = SELF.value
+        val paymentAmountIsCorrect = expectedPaymentAmount == sentPaymentAmount
+
+        val expectedReceiverAddress = INPUTS(0).R6[Coll[Byte]].get
+        val proposedReceiverAddress = OUTPUTS(0).propositionBytes
+        val receiverAddressIsCorrect = expectedReceiverAddress == proposedReceiverAddress
+
+        val tokenCanBeMinted = proposedTokenIsValidNFT &&
+                               tokenNameIsCorrect &&
+                               paymentAmountIsCorrect &&
+                               receiverAddressIsCorrect &&
+                               ergoNamesPk
+
+        sigmaProp(tokenCanBeMinted)
       }
       """.stripMargin
 

--- a/src/main/scala/SpendBoxAtMintContractAddress/SpendBoxAtMintContractAddress.scala
+++ b/src/main/scala/SpendBoxAtMintContractAddress/SpendBoxAtMintContractAddress.scala
@@ -29,8 +29,7 @@ object SpendBoxAtMintContractAddress {
       val senderProver: ErgoProver = ctx.newProverBuilder
         .withMnemonic(
           SecretString.create(nodeConf.getWallet.getMnemonic),
-          SecretString.create(nodeConf.getWallet.getPassword)
-        )
+          SecretString.create(nodeConf.getWallet.getPassword))
         .withEip3Secret(addressIndex)
         .build()
 
@@ -42,16 +41,18 @@ object SpendBoxAtMintContractAddress {
         .collect(Collectors.toList())
 
       // Amount to retrieve from nft minting request box - this is essentially collecting payment for the mint
-      val amountToSend: Long = 25000000L - Parameters.MinFee
+      val paymentAmount: Long = conf.getParameters.get("paymentAmount").toLong
+      val amountToSend: Long = paymentAmount - Parameters.MinFee
 
       // Create unsigned tx builder
       val txB: UnsignedTransactionBuilder = ctx.newTxBuilder
 
       // Create output box
+      // TODO: pull these from input registers
       val proposedToken: ErgoToken = new ErgoToken(spendingBoxes.get(0).getId, 1)
-      val tokenName: String = "contract_issued_nft_test.erg"
-      val tokenDescription: String = "Early stage testing of token minting with contracts"
-      val tokenDecimals: Int = 0
+      val tokenName: String = conf.getParameters.get("tokenName")
+      val tokenDescription: String = conf.getParameters.get("tokenDescription")
+      val tokenDecimals: Int = conf.getParameters.get("tokenDecimals").toInt
 
       val newBox: OutBox = txB.outBoxBuilder
         .mintToken(proposedToken, tokenName, tokenDescription, tokenDecimals)

--- a/src/main/scala/SubmitPaymentForNFT/SubmitPaymentForNFT.scala
+++ b/src/main/scala/SubmitPaymentForNFT/SubmitPaymentForNFT.scala
@@ -1,0 +1,80 @@
+package SubmitPaymentForNFT
+
+import org.ergoplatform.appkit._
+import org.ergoplatform.appkit.config.{ErgoNodeConfig, ErgoToolConfig}
+import org.ergoplatform.appkit.impl.ErgoTreeContract
+import sigmastate.eval.Colls
+import special.collection.Coll
+
+object SubmitPaymentForNFT {
+  def submitPaymentForNFT(configFileName: String): String = {
+    // Node configuration values
+    val conf: ErgoToolConfig = ErgoToolConfig.load(configFileName)
+    val nodeConf: ErgoNodeConfig = conf.getNode
+    val explorerUrl: String = RestApiErgoClient.getDefaultExplorerUrl(NetworkType.TESTNET)
+
+    // Fetch parameters from config
+    val addressIndex: Int = conf.getParameters.get("addressIndex").toInt
+    val mintingContractAddress: Address = Address.create(conf.getParameters.get("mintingContractAddress"))
+    val tokenName: String = conf.getParameters.get("tokenName")
+    val paymentAmount: Long = conf.getParameters.get("paymentAmount").toLong
+    val nftReceiverAddress: Address = Address.create(conf.getParameters.get("nftReceiverAddress"))
+
+    // Create ErgoClient instance (represents a connection to node)
+    val ergoClient: ErgoClient = RestApiErgoClient.create(nodeConf, explorerUrl)
+
+    val txJson: String = ergoClient.execute((ctx: BlockchainContext) => {
+
+      // Initialize prover (signs the transaction)
+      val senderProver: ErgoProver = ctx.newProverBuilder
+        .withMnemonic(
+          SecretString.create(nodeConf.getWallet.getMnemonic),
+          SecretString.create(nodeConf.getWallet.getPassword))
+        .withEip3Secret(addressIndex)
+        .build()
+
+      // Get input (spending) boxes from node wallet
+      val wallet: ErgoWallet = ctx.getWallet
+      val amountToSpend: Long = paymentAmount
+      val totalToSpend: Long = amountToSpend + Parameters.MinFee
+      val boxes: java.util.Optional[java.util.List[InputBox]] = wallet.getUnspentBoxes(totalToSpend)
+      if (!boxes.isPresent)
+        throw new ErgoClientException(s"Not enough coins in the wallet to pay $totalToSpend", null)
+
+      // Create unsigned tx builder
+      val txBuilder: UnsignedTransactionBuilder = ctx.newTxBuilder()
+
+      // Create output box
+      val expectedTokenName: ErgoValue[Coll[Byte]] = ErgoValue.of(tokenName.getBytes)
+      val expectedPaymentAmount: ErgoValue[Long] = ErgoValue.of(paymentAmount)
+      val receiverAddressBytes: Coll[Byte] = Colls.fromArray(nftReceiverAddress.getErgoAddress.script.bytes)
+      val expectedReceiverAddress: ErgoValue[Coll[Byte]] = ErgoValue.of(receiverAddressBytes, ErgoType.byteType)
+
+      val newBox = txBuilder.outBoxBuilder
+        .value(amountToSpend)
+        .contract(new ErgoTreeContract(mintingContractAddress.getErgoAddress.script))
+        .registers(expectedTokenName, expectedPaymentAmount, expectedReceiverAddress)
+        .build()
+
+      // Create unsigned transaction
+      val tx: UnsignedTransaction = txBuilder
+        .boxesToSpend(boxes.get)
+        .outputs(newBox)
+        .fee(Parameters.MinFee)
+        .sendChangeTo(senderProver.getP2PKAddress)
+        .build()
+
+      val signed: SignedTransaction = senderProver.sign(tx)
+
+      val txId: String = ctx.sendTransaction(signed)
+
+      signed.toJson(true)
+    })
+    txJson
+  }
+
+  def main(args: Array[String]): Unit = {
+    val txJson: String = submitPaymentForNFT("config.json")
+    println(txJson)
+  }
+}


### PR DESCRIPTION
Initial contract version checked that ErgoNamesPk was signing for the minting tx, and that token passed some basic integrity checks.

This version of the contract adds some additional checks.
To do so, it makes a few assumptions; it expects some values to be set in some registers.
R4 - Name of the token the user wants to mint (a note on the current use of this register later)
R5 - Expected payment amount
R6 - The address of the user (so we can send back the NFT)

These values are expected to be set by the frontend component that builds the "minting request" on behalf of the user.
In other words, these values are expected to be set by a component of our system.

With these conventions established, the contract performs a few additional checks.
- Verify the token to be minted has the name the user asked for
- Verify the user sent the correct payment amount
- Verify the token would go back to the user

Only if those conditions are met, and it's our PK signing for the tx that spends the "minting request box", can the box be spent. Otherwise, the tx will fail.

These are some nice additions to the contract, but it is still missing some key features.
With that said, a few notes:

- Regarding R4: We intend to implement royalty reflections on secondary market sales. Per [EIP-0024](https://github.com/ergoplatform/eips/blob/master/eip-0024.md), royalty percentage should be specified in R4 of the issuer box (in our case, the "minting request box"). In the next iteration of the contract, all current register allocations should be bumped 1 slot down so we can set royalty percentage in R4.

- Regarding payment amount: Currently, the contract only verifies the correct payment amount was sent by the user. However, it doesn't verify _who_ that payment goes to! In the next iteration, the contract should be updated to verify payment is directed to an address or contract (a discussion could be had on this) to which ErgoNames has spending rights.

- Regarding potential refunds: Currently the contract does not allow for issuing potential refunds. If a box is sent to the contract address that doesn't pass all checks, the funds would be locked and ErgoNames wouldn't have the ability to issue a refund back to the user! So, the contract's next iteration should account for this.

- Regarding royalty reflections:  Per [EIP-0024](https://github.com/ergoplatform/eips/blob/master/eip-0024.md), if royalty percentage is set in R4 of the issuer box, royalties will be sent to the address that provided that box as an input to the tx that issued the asset. In this case, the address would be the contract's, so any royalties would be reflected back to it. In its current state, any reflected royalties collected at the contract address would be locked and uncollectable! Clearly we do not want that, so the next iteration of the contract should, at the very least, propose a solution to circumvent that problem. More details to come about this subject in the next contract iteration.

- Regarding minting request verification: Anyone can create a box and send it to any address. While the contract allows only us to spend boxes at its address, if a bad actor figures out the contract's requirements and sends a compliant box to it, there is currently nothing stopping us from processing that box, potentially executing a double mint, or just a mint for which we did not generate a request on behalf of a user. A solution has been proposed to avoid this: in the minting request box, include a signed message in one of the registers that only could have been signed with the ErgoNames PK. Then, in the contract or off chain, verify the signature. If it can't be verified, we do not process that request. Otherwise, we do. While this solution is very much doable, there are some technical caveats we need to consider before expecting a full fledged implementation. So, while this security check is not expected to be implemented in the contract's next iteration, it is something we definitely want to start thinking about as it will be an important check to have before the contract can be considered production ready.


