### PR TITLE
Lambda handler for minting contract

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,4 +4,14 @@ scalaVersion := "2.12.15"
 
 libraryDependencies += "org.ergoplatform" %% "ergo-appkit" % "4.0.7"
 libraryDependencies += "io.github.dav009" %% "ergopuppet" % "0.0.0+28-8ee0ca24+20220219-2144"  % Test
+libraryDependencies += "org.mockito" % "mockito-core" % "4.3.1" % Test
+libraryDependencies += "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
+libraryDependencies += "com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.2"
 libraryDependencies += ("org.scorexfoundation" %% "sigma-state" % "4.0.5" ).classifier("tests")
+
+
+assemblyMergeStrategy in assembly := {
+ case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+ case x => MergeStrategy.first
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")

--- a/src/main/scala/scenarios/ProcessMintingRequest.scala
+++ b/src/main/scala/scenarios/ProcessMintingRequest.scala
@@ -1,12 +1,22 @@
 package scenarios
 
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.{SQSEvent}
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
 import org.ergoplatform.appkit.{Address, BlockchainContext, ErgoClientException, InputBox, NetworkType, Parameters}
 import org.ergoplatform.appkit.config.ErgoToolConfig
 import utils.ErgoNamesUtils
 
 import scala.collection.JavaConverters._
 
-object ProcessMintingRequest {
+case class MintRequestSqsMessage(tokenDescription: String, mintRequestBoxId: String)
+
+
+trait Minter{
+  implicit val mintRequestSqsMessageReads = Json.reads[MintRequestSqsMessage]
+  implicit val mintRequestSqsMessageWrites = Json.writes[MintRequestSqsMessage]
 
   def createTx(ctx: BlockchainContext,
     inputs: java.util.List[InputBox],
@@ -14,7 +24,7 @@ object ProcessMintingRequest {
     mintRequestBox: InputBox,
     ergoNamesStandardTokenDescription: String,  networkType: NetworkType) = {
 
-         val issuanceBox = ErgoNamesUtils.buildBoxWithTokenToMint(
+        val issuanceBox = ErgoNamesUtils.buildBoxWithTokenToMint(
           ctx,
           networkType,
           value = Parameters.MinChangeValue,
@@ -38,14 +48,11 @@ object ProcessMintingRequest {
         tx
   }
 
-  def processMintingRequest(conf: ErgoToolConfig, networkType: NetworkType): String = {
-    val ergoClient = ErgoNamesUtils.buildErgoClient(conf.getNode, networkType)
-
-    val mintingContractAddress = Address.create(conf.getParameters.get("mintingContractAddress"))
-    val mintRequestBoxId = conf.getParameters.get("nftMintRequestBoxId")
-    val ergoNamesStandardTokenDescription = conf.getParameters.get("tokenDescription")
-
-    val txJson: String = ergoClient.execute((ctx: BlockchainContext) => {
+  def processMintingRequest(conf: ErgoToolConfig, networkType: NetworkType, mintContractAddress:String, mintRequestBoxId: String,  ergoNamesStandardTokenDescription: String): String = {
+    
+        val ergoClient = ErgoNamesUtils.buildErgoClient(conf.getNode, networkType)
+        val mintingContractAddress = Address.create(mintContractAddress)
+        val txJson: String = ergoClient.execute((ctx: BlockchainContext) => {
         val senderProver = ErgoNamesUtils.buildProver(ctx, conf.getNode)
 
         val mintRequestBox = ErgoNamesUtils.getMintRequestBox(ctx, mintingContractAddress, mintRequestBoxId)
@@ -56,8 +63,6 @@ object ProcessMintingRequest {
         val boxesToSpend = ErgoNamesUtils.getBoxesToSpendFromWallet(ctx, totalToSpend = Parameters.MinFee)
         if (!boxesToSpend.isPresent)
           throw new ErgoClientException(s"Not enough coins in the wallet to pay ${Parameters.MinFee}", null)
-
-
 
         // TODO: Move to ErgoNamesUtils
       val inputs = List.concat(List(mintRequestBox), boxesToSpend.get.asScala)
@@ -70,10 +75,40 @@ object ProcessMintingRequest {
     txJson
   }
 
+ /*
+  This function is an entrypoint for an AWS lambda consuming events form sqs.
+   - aws feeds a SQSEvent to this function.
+   - a SQSEvent contains multiple SQS messages
+   - this function expects each sqs message to be a json string describe by MintRequestSqsMessage
+   - this function parses each json sqs message into a MintRequestSqsMessage object
+   - then it feeds each MintRequestSqsMessage to the function which mints a domain
+ */
+  def lambdaEventHandler(sqsEvent: SQSEvent, context: Context) : Unit = {
+        val conf: ErgoToolConfig = ErgoToolConfig.load("config.json")
+        val networkType = if (conf.getNode.getNetworkType == "TESTNET") NetworkType.TESTNET else NetworkType.MAINNET
+       val mintingContractAddress = conf.getParameters.get("mintingContractAddress")
+       val sqsMessages = sqsEvent.getRecords().asScala
+       val mintRequests = sqsMessages.map(_.getBody())
+                                     .map(Json.parse(_).as[MintRequestSqsMessage])
+       mintRequests.map{
+              mintRequest =>
+             // ToDo handle failures here so that a single request failure does not taint the entire batch of sqs messages
+             processMintingRequest(conf, networkType, mintingContractAddress,
+             mintRequest.mintRequestBoxId, mintRequest.tokenDescription)
+             // ToDo delete sqs message if successful
+      }
+
+  }
+}
+
+object ProcessMintingRequest extends Minter {
   def main(args: Array[String]) : Unit = {
     val conf: ErgoToolConfig = ErgoToolConfig.load("config.json")
     val networkType = if (conf.getNode.getNetworkType == "TESTNET") NetworkType.TESTNET else NetworkType.MAINNET
-    val txJson = processMintingRequest(conf, networkType)
+    val tokenDesc = conf.getParameters.get("tokenDescription")
+    val mintRequestBoxId = conf.getParameters.get("nftMintRequestBoxId")
+    val mintingContractAddress = conf.getParameters.get("mintingContractAddress")
+    val txJson = processMintingRequest(conf, networkType, mintingContractAddress, mintRequestBoxId, tokenDesc)
     print(txJson)
   }
 }

--- a/src/test/scala/scenarios/MintLambdaSpec.scala
+++ b/src/test/scala/scenarios/MintLambdaSpec.scala
@@ -1,0 +1,56 @@
+package scenarios
+
+import scenarios.ProcessMintingRequest
+import scenarios.ProcessMintingRequest._
+import scenarios.Minter
+
+import org.scalatest.{ PropSpec, Matchers }
+import org.ergoplatform.ErgoAddressEncoder
+import org.scalatest._
+import org.scalatest.Assertions._
+import org.scalatest.{ Matchers, WordSpecLike }
+import org.scalatest.mockito.MockitoSugar
+
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+import org.mockito.ArgumentCaptor
+
+import com.amazonaws.services.lambda.runtime.events.{SQSEvent}
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import com.amazonaws.services.lambda.runtime.Context
+
+import play.api.libs.json._
+
+
+import scala.collection.JavaConverters._
+
+ class TestableMinter extends Minter
+
+class ProcessMintLambdaSpec extends WordSpecLike with Matchers with MockitoSugar {
+
+  "should handle sqs events" in {
+    val event = mock[SQSEvent]
+    val lambdaCtx = mock[Context]
+    val request1 = new SQSMessage()
+    request1.setBody(Json.toJson(MintRequestSqsMessage("dummy desc1", "box1")).toString())
+    val request2 = new SQSMessage()
+    request2.setBody(Json.toJson(MintRequestSqsMessage("dummy desc2", "box2")).toString())
+    val mockedProcessMintingRequest = spy(new TestableMinter)
+    doAnswer(_=>"dummyTx")
+    .when(mockedProcessMintingRequest)
+    .processMintingRequest(any(), any(), any(), any(), any())
+    val argumentBoxId = ArgumentCaptor.forClass(classOf[String])
+    val argumentDesc = ArgumentCaptor.forClass(classOf[String])
+    when(event.getRecords).thenReturn(List(request1, request2).asJava)
+    mockedProcessMintingRequest.lambdaEventHandler(event, lambdaCtx)
+    verify(mockedProcessMintingRequest, times(2)).processMintingRequest(any(),any(),any(),argumentBoxId.capture(), argumentDesc.capture())
+
+    assert(List("box1", "box2").asJava == argumentBoxId.getAllValues())
+    assert(List("dummy desc1", "dummy desc2").asJava == argumentDesc.getAllValues())
+  }
+
+  // ToDo should handle failing minting requests
+
+  // ToDo should assert that successful mints delete sqs messages
+
+}


### PR DESCRIPTION
## Why do we need this PR?

This PR prepares this codebase for being used in lambda functions.

## Whats in this PR?

- added the `assembly` plugin. if you do : `sbt assembly` it will generate a `"fat jar"`. This fat jar contains all dependencies and our code compiled. This jar can be ran in a lambda function

- added a scala function that serves as a handler when being called from a lambda function `lambdaEventHandler`. This function can consume a `SQSEvent`. A SQSEvent contains many SQSMessages. 

- `case class MintRequestSqsMessage` represents the data contained in the SQS messages that we are going to receive. Every SQS messages for minting should contain this data in json format. During execution time we are marshalling and unmarshalling json using this class

- I had to refactor a few bits so that I could inject  mocks in the tests I added.

## But have you ran this on lambda already?

- Not yet, but this should be a start before we get there