### PR TITLE
no jackson / better config management

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ name := "ergo-names-backend"
 scalaVersion := "2.12.15"
 
 // Scala dependencies
-libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2"
 libraryDependencies += "org.ergoplatform" %% "ergo-appkit" % "4.0.7"
 libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.2"
 libraryDependencies += "io.github.dav009" %% "ergopuppet" % "0.0.0+28-8ee0ca24+20220219-2144"  % Test

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "queueUrl": "https://sqs.us-east-2.amazonaws.com/453627713520/mint-requests-queue-testnet",
+    "mintRequestsQueueUrl": "https://sqs.us-east-2.amazonaws.com/453627713520/mint-requests-queue-testnet",
     "dry": true,
     "secretName": "ergo-node-testnet-config",
     "awsRegion": "us-east-2"

--- a/src/main/scala/models/ErgoNamesConfig.scala
+++ b/src/main/scala/models/ErgoNamesConfig.scala
@@ -1,3 +1,3 @@
 package models
 
-case class ErgoNamesConfig(mintRequestsQueue: String, dry: Boolean, secretName: String, awsRegion: String)
+case class ErgoNamesConfig(mintRequestsQueueUrl: String, dry: Boolean, secretName: String, awsRegion: String)

--- a/src/main/scala/scenarios/ProcessMintingRequest.scala
+++ b/src/main/scala/scenarios/ProcessMintingRequest.scala
@@ -105,15 +105,12 @@ trait Minter {
   def lambdaEventHandler(sqsEvent: SQSEvent, context: Context) : Unit = {
 
         // Getting a config from env or from file
-    val config: ErgoNamesConfig = ConfigManager.getConfig match {
+        val config: ErgoNamesConfig = ConfigManager.getConfig match {
           case Success(c) => c
           case Failure(x) => throw new Exception(x)
         }
-        //println("Getting AWS region")
-        //val awsRegion = AwsHelper.getRegion.get
-        //println("Getting AWS Secrets Manager, secret name for Ergo node config")
-        //val secretName = ConfigManager.get("secretName")
-        //println(s"Getting secret $secretName from AWS Secrets Manager")
+
+        println(s"Getting secret $config.secretName from AWS Secrets Manager")
         val secretString = AwsHelper.getSecretFromSecretsManager(config.secretName, config.awsRegion)
         println("Parsing secret string into ErgoToolConfig type")
         val ergoNodeConfig = ErgoToolConfig.load(new StringReader(secretString))

--- a/src/main/scala/utils/AwsHelper.scala
+++ b/src/main/scala/utils/AwsHelper.scala
@@ -4,12 +4,6 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest
 
 object AwsHelper {
-  def getRegion: String = {
-    val env = sys.env.getOrElse("AWS_REGION", null)
-    if (env != null) return env
-    val local = ConfigManager.getJsonConfigAsMap.getOrElse("awsRegion", null)
-    local
-  }
 
   def getSecretFromSecretsManager(secretName: String, region: String): String = {
     val client = AWSSecretsManagerClientBuilder.standard()

--- a/src/main/scala/utils/ConfigManager.scala
+++ b/src/main/scala/utils/ConfigManager.scala
@@ -14,7 +14,10 @@ object ConfigManager {
        val mintRequestsQueueUrl = sys.env.get("mintRequestsQueueUrl").get
        val dry = sys.env.get("dry").get.toBoolean
        val secretName = sys.env.get("secretName").get
-       val awsRegion = sys.env.get("awsRegion").get
+       val awsRegion = sys.env.get("awsRegion") match {
+         case Some(r) => r
+         case None => sys.env.get("AWS_REGION").get  
+       }
        ErgoNamesConfig(mintRequestsQueueUrl, dry, secretName, awsRegion)
      }
     )

--- a/src/main/scala/utils/ConfigManager.scala
+++ b/src/main/scala/utils/ConfigManager.scala
@@ -34,10 +34,10 @@ object ConfigManager {
     // try to read config from env
     // otherwise revert to try to read config from file
     // fail if a valid config can't be created from either
-    Try(fromEnv()) match {
-      case Success(c) => c
-      case Failure(_) => {
-        println("using configuration from file")
+    fromEnv() match {
+      case Success(c) => Success(c)
+      case Failure(r) => {
+        println("reading config from file..")
         fromFile()
       }
     }

--- a/src/test/scala/utils/ConfigSpec.scala
+++ b/src/test/scala/utils/ConfigSpec.scala
@@ -1,0 +1,77 @@
+package utils
+
+import org.scalatest._
+import org.scalatest.Assertions._
+import org.scalatest.{ Matchers, WordSpecLike }
+import org.scalatest.mockito.MockitoSugar
+import scala.util.{Try,Success,Failure}
+
+class ConfigSpec extends WordSpecLike with Matchers with MockitoSugar {
+
+  // utility to be able to mock env vars during testing
+  //https://stackoverflow.com/questions/34028195/how-do-i-test-code-that-requires-an-environment-variable
+  def setEnv(key: String, value: String) = {
+    val field = System.getenv().getClass.getDeclaredField("m")
+    field.setAccessible(true)
+    val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
+    map.put(key, value)
+  }
+
+  // utility to be able to mock env vars during testing
+  //https://stackoverflow.com/questions/34028195/how-do-i-test-code-that-requires-an-environment-variable
+  def delEnv(key: String) = {
+    val field = System.getenv().getClass.getDeclaredField("m")
+    field.setAccessible(true)
+    val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
+    map.remove(key)
+  }
+
+  def setDummyEnv(){
+    setEnv("mintRequestsQueueUrl", "ENVQUEUE")
+    setEnv("dry", "true")
+    setEnv("secretName", "ENVSECRET")
+    setEnv("awsRegion", "ENVREGION")
+  }
+
+  def cleanDummyEnv(){
+    delEnv("mintRequestsQueueUrl")
+    delEnv("dry")
+    delEnv("secretName")
+    delEnv("awsRegion") 
+  }
+
+  "should load config from env" in {
+    // a failure if there are not env variables
+    assert(ConfigManager.fromEnv() match {
+      case Success(c) => false
+      case Failure(r) => true  
+    })
+  }
+
+  "should load config from file " in {
+    // a failure if there are not env variables
+    val okConfig = ConfigManager.fromFile().toOption.get
+    assert(okConfig.mintRequestsQueueUrl=="https://sqs.us-east-2.amazonaws.com/453627713520/mint-requests-queue-testnet")
+    assert(okConfig.dry==true)
+    assert(okConfig.secretName=="ergo-node-testnet-config")
+    assert(okConfig.awsRegion=="us-east-2")
+  }
+
+  "should prefer loading config from env " in {
+    setDummyEnv()
+    val okConfig = ConfigManager.getConfig().toOption.get
+    assert(okConfig.mintRequestsQueueUrl=="ENVQUEUE")
+    assert(okConfig.dry)
+    assert(okConfig.secretName=="ENVSECRET")
+    assert(okConfig.awsRegion=="ENVREGION")
+    cleanDummyEnv()
+  }
+
+  "should default to loading config from file if no env" in {
+    val okConfig = ConfigManager.getConfig().toOption.get
+    assert(okConfig.mintRequestsQueueUrl=="https://sqs.us-east-2.amazonaws.com/453627713520/mint-requests-queue-testnet")
+    assert(okConfig.dry==true)
+    assert(okConfig.secretName=="ergo-node-testnet-config")
+    assert(okConfig.awsRegion=="us-east-2")
+  }
+}


### PR DESCRIPTION
## Why do we need this PR?

- Main reason is: getting rid of Jackson. 
- **The more deps we have the more memory our Lambda function will consume :(** 
- Ended up refactoring the way we create our config data structure.
  - The way it used to work: read variables from environment, cast in various places
  - Now? it works by trying to create a `ErgoNamesConfig` from env
  - If that fails, then try to create a `ErgoNamesConfig` from a file 
  - If both fails, throws exception.
  - use the created `ErgoNamesConfig` in the rest of the main 
- I think mostly this consolidates all the error and cast typing in one function as oppose as having it all over the main function. However this is just my opinion

## Have you tested this?
No, thus a draft PR.

## What's next ?
- Better SQS error handling
- Create ErgoClient  once
  
 