### PR TITLE
scalafmt + code formatting

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,11 @@
+align = none
+align.openParenDefnSite = false
+align.openParenCallSite = false
+align.tokens = []
+optIn = {
+  configStyleArguments = false
+}
+danglingParentheses = false
+docstrings = JavaDoc
+maxColumn = 120
+version=2.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")

--- a/src/main/scala/scenarios/ProcessMintingRequest.scala
+++ b/src/main/scala/scenarios/ProcessMintingRequest.scala
@@ -1,6 +1,5 @@
 package scenarios
 
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
@@ -8,83 +7,100 @@ import models.{ErgoNamesConfig, MintRequestSqsMessage, MintingTxArgs}
 import org.ergoplatform.appkit._
 import org.ergoplatform.appkit.config.{ErgoToolConfig}
 import play.api.libs.json._
-import scala.util.{Try,Success,Failure}
+import scala.util.{Try, Success, Failure}
 import utils.{AwsHelper, ConfigManager, ErgoNamesUtils}
 
 import java.io.StringReader
 import scala.collection.JavaConverters._
 
 trait Minter {
-  implicit val mintRequestSqsMessageReads: Reads[MintRequestSqsMessage] = Json.reads[MintRequestSqsMessage]
-  implicit val mintRequestSqsMessageWrites: OWrites[MintRequestSqsMessage] = Json.writes[MintRequestSqsMessage]
+  implicit val mintRequestSqsMessageReads: Reads[MintRequestSqsMessage] =
+    Json.reads[MintRequestSqsMessage]
+  implicit val mintRequestSqsMessageWrites: OWrites[MintRequestSqsMessage] =
+    Json.writes[MintRequestSqsMessage]
 
-  def createTx(ctx: BlockchainContext,
-               boxesToCoverTxFees: java.util.List[InputBox],
-               senderAddress: Address,
-               mintRequestBox: InputBox,
-               ergoNamesStandardTokenDescription: String): (UnsignedTransaction, MintingTxArgs) = {
-          println("Building issuance box arguments")
-          val (token, tokenName, tokenDesc, tokenDecimals, ergValue, contract) = ErgoNamesUtils.issuanceBoxArgs(
-            ctx.getNetworkType,
-            value = Parameters.MinChangeValue,
-            mintRequestBox, // contains some register data to be extracted
-            tokenDescription = ergoNamesStandardTokenDescription)
+  def createTx(
+      ctx: BlockchainContext,
+      boxesToCoverTxFees: java.util.List[InputBox],
+      senderAddress: Address,
+      mintRequestBox: InputBox,
+      ergoNamesStandardTokenDescription: String): (UnsignedTransaction, MintingTxArgs) = {
+    println("Building issuance box arguments")
+    val (token, tokenName, tokenDesc, tokenDecimals, ergValue, contract) =
+      ErgoNamesUtils.issuanceBoxArgs(
+        ctx.getNetworkType,
+        value = Parameters.MinChangeValue,
+        mintRequestBox, // contains some register data to be extracted
+        tokenDescription = ergoNamesStandardTokenDescription)
 
-          println("Building issuance box")
-          val issuanceBox = ErgoNamesUtils.buildBoxWithTokenToMint(ctx,
-            token, tokenName, tokenDesc,
-            tokenDecimals, ergValue, contract)
+    println("Building issuance box")
+    val issuanceBox =
+      ErgoNamesUtils.buildBoxWithTokenToMint(ctx, token, tokenName, tokenDesc, tokenDecimals, ergValue, contract)
 
-          println("Building payment collection box")
-          val paymentCollectionBox = ErgoNamesUtils.buildPaymentCollectionBox(
-            ctx,
-            mintRequestBox,
-            senderAddress.asP2PK())
+    println("Building payment collection box")
+    val paymentCollectionBox =
+      ErgoNamesUtils.buildPaymentCollectionBox(ctx, mintRequestBox, senderAddress.asP2PK())
 
-          val inputsWithMintBox =  List(mintRequestBox) ++ (boxesToCoverTxFees).asScala
+    val inputsWithMintBox = List(mintRequestBox) ++ (boxesToCoverTxFees).asScala
 
-          println("Building minting tx")
-          val tx = ctx.newTxBuilder
-            .boxesToSpend(inputsWithMintBox.asJava)
-            .outputs(issuanceBox, paymentCollectionBox)
-            .fee(Parameters.MinFee)
-            .sendChangeTo(senderAddress.asP2PK())
-            .build()
+    println("Building minting tx")
+    val tx = ctx.newTxBuilder
+      .boxesToSpend(inputsWithMintBox.asJava)
+      .outputs(issuanceBox, paymentCollectionBox)
+      .fee(Parameters.MinFee)
+      .sendChangeTo(senderAddress.asP2PK())
+      .build()
 
-          val txArgs = MintingTxArgs(inputsWithMintBox, List(issuanceBox, paymentCollectionBox), Parameters.MinFee, senderAddress.asP2PK())
+    val txArgs = MintingTxArgs(
+      inputsWithMintBox,
+      List(issuanceBox, paymentCollectionBox),
+      Parameters.MinFee,
+      senderAddress.asP2PK())
 
-          (tx, txArgs)
-    }
+    (tx, txArgs)
+  }
 
   // TODO: Consider passing ErgoClient and ErgoProver
-  def mint(ergoClient: ErgoClient, conf: ErgoToolConfig, mintingContractAddress: Address, mintRequestBoxId: String,  ergoNamesStandardTokenDescription: String): String = {
-        val txJson: String = ergoClient.execute((ctx: BlockchainContext) => {
-            println("Building prover")
-            val senderProver = ErgoNamesUtils.buildProver(ctx, conf.getNode)
+  def mint(
+      ergoClient: ErgoClient,
+      conf: ErgoToolConfig,
+      mintingContractAddress: Address,
+      mintRequestBoxId: String,
+      ergoNamesStandardTokenDescription: String): String = {
+    val txJson: String = ergoClient.execute((ctx: BlockchainContext) => {
+      println("Building prover")
+      val senderProver = ErgoNamesUtils.buildProver(ctx, conf.getNode)
 
-            println(s"Fetching mint request box with id $mintRequestBoxId from contract address $mintingContractAddress")
-            val mintRequestBox = ErgoNamesUtils.getMintRequestBox(ctx, mintingContractAddress, mintRequestBoxId)
-            if (mintRequestBox == null)
-              throw new ErgoClientException(s"Could not find mint request with box id $mintRequestBoxId", null)
+      println(s"Fetching mint request box with id $mintRequestBoxId from contract address $mintingContractAddress")
+      val mintRequestBox =
+        ErgoNamesUtils.getMintRequestBox(ctx, mintingContractAddress, mintRequestBoxId)
+      if (mintRequestBox == null)
+        throw new ErgoClientException(s"Could not find mint request with box id $mintRequestBoxId", null)
 
-            println(s"Getting ${Parameters.MinFee} nanoergs from wallet to cover tx fee")
-            // TODO: Alternatively, consider including tx fee as part of payment.
-            //  This way, we don't need to fetch boxes from the ErgoNames wallet, which would result in one less call to the node.
-            val boxesToCoverTxFees = ErgoNamesUtils.getBoxesToSpendFromWallet(ctx, totalToSpend = Parameters.MinFee)
-            if (!boxesToCoverTxFees.isPresent)
-              throw new ErgoClientException(s"Not enough coins in the wallet to pay ${Parameters.MinFee}", null)
+      println(s"Getting ${Parameters.MinFee} nanoergs from wallet to cover tx fee")
+      // TODO: Alternatively, consider including tx fee as part of payment.
+      //  This way, we don't need to fetch boxes from the ErgoNames wallet, which would result in one less call to the node.
+      val boxesToCoverTxFees =
+        ErgoNamesUtils.getBoxesToSpendFromWallet(ctx, totalToSpend = Parameters.MinFee)
+      if (!boxesToCoverTxFees.isPresent)
+        throw new ErgoClientException(s"Not enough coins in the wallet to pay ${Parameters.MinFee}", null)
 
-            // TODO: Consider passing concatenated inputs to createTx. Would reduce number of params AND wouldnt need to concat them again later
-            val (tx, _) = createTx(ctx, boxesToCoverTxFees.get, senderProver.getAddress, mintRequestBox, ergoNamesStandardTokenDescription)
+      // TODO: Consider passing concatenated inputs to createTx. Would reduce number of params AND wouldnt need to concat them again later
+      val (tx, _) = createTx(
+        ctx,
+        boxesToCoverTxFees.get,
+        senderProver.getAddress,
+        mintRequestBox,
+        ergoNamesStandardTokenDescription)
 
-            println("Signing minting tx")
-            val signedTx = senderProver.sign(tx)
-            println("Sending signed minting to node")
-            val txId = ctx.sendTransaction(signedTx)
+      println("Signing minting tx")
+      val signedTx = senderProver.sign(tx)
+      println("Sending signed minting to node")
+      val txId = ctx.sendTransaction(signedTx)
 
-            signedTx.toJson(true)
-        })
-        txJson
+      signedTx.toJson(true)
+    })
+    txJson
   }
 
   def getSqsClient(region: String): AmazonSQS = {
@@ -92,12 +108,22 @@ trait Minter {
     sqsClient
   }
 
-  def processSqsMessage(sqsClient: AmazonSQS, message: SQSEvent.SQSMessage, mintRequest:MintRequestSqsMessage, ergoClient: ErgoClient, ergoNodeConfig: ErgoToolConfig, mintingContractAddress: Address, dry: Boolean, queueUrl: String): String = {
-    if (dry){
+  def processSqsMessage(
+      sqsClient: AmazonSQS,
+      message: SQSEvent.SQSMessage,
+      mintRequest: MintRequestSqsMessage,
+      ergoClient: ErgoClient,
+      ergoNodeConfig: ErgoToolConfig,
+      mintingContractAddress: Address,
+      dry: Boolean,
+      queueUrl: String): String = {
+    if (dry) {
       "DryDummyTx"
     } else {
-      println(s"Attempting to process mint request box ${mintRequest.mintRequestBoxId} issued by mint tx ${mintRequest.mintTxId}")
-      val txJson = mint(ergoClient,
+      println(
+        s"Attempting to process mint request box ${mintRequest.mintRequestBoxId} issued by mint tx ${mintRequest.mintTxId}")
+      val txJson = mint(
+        ergoClient,
         ergoNodeConfig,
         mintingContractAddress,
         mintRequest.mintRequestBoxId,
@@ -110,81 +136,93 @@ trait Minter {
     }
   }
 
- /*
+  /*
   This function is an entrypoint for an AWS lambda consuming events form sqs.
    - aws feeds a SQSEvent to this function.
    - an SQSEvent contains multiple SQS messages
    - this function expects each sqs message to be a json string described by MintRequestSqsMessage
    - this function parses each json sqs message into a MintRequestSqsMessage object
    - then it feeds each MintRequestSqsMessage to the function which mints an ergoname NFT
- */
-  def lambdaEventHandler(sqsEvent: SQSEvent, context: Context) : Unit = {
+   */
+  def lambdaEventHandler(sqsEvent: SQSEvent, context: Context): Unit = {
 
-        // Getting a config from env or from file
-        val config: ErgoNamesConfig = ConfigManager.getConfig match {
-          case Success(c) => c
-          case Failure(x) => throw new Exception(x)
+    // Getting a config from env or from file
+    val config: ErgoNamesConfig = ConfigManager.getConfig match {
+      case Success(c) => c
+      case Failure(x) => throw new Exception(x)
+    }
+
+    println(s"Getting secret $config.secretName from AWS Secrets Manager")
+    val secretString = AwsHelper.getSecretFromSecretsManager(config.secretName, config.awsRegion)
+    println("Parsing secret string into ErgoToolConfig type")
+    val ergoNodeConfig = ErgoToolConfig.load(new StringReader(secretString))
+
+    val networkType = ergoNodeConfig.getNode.getNetworkType
+    println(s"Targeting $networkType")
+
+    // TODO: Update minting method to take an ergoClient rather than a config to instantiate one
+    println(s"Building Ergo client for interacting with node at ${ergoNodeConfig.getNode.getNodeApi.getApiUrl}")
+    val ergoClient = ErgoNamesUtils.buildErgoClient(ergoNodeConfig.getNode, ergoNodeConfig.getNode.getNetworkType)
+
+    val mintingContractAddress =
+      Address.create(ergoNodeConfig.getParameters.get("mintingContractAddress"))
+    println(s"Minting Contract Address: $mintingContractAddress")
+
+    val queueUrl = config.mintRequestsQueueUrl
+    println(s"Building AWS SQS Client for queue $queueUrl")
+    val sqsClient = getSqsClient(config.awsRegion)
+
+    val sqsMessages = sqsEvent.getRecords.asScala
+    println(s"Pulled ${sqsMessages.length} message(s) from queue")
+    println("Extracting and parsing mint request(s) from SQS message(s)")
+    val mintRequests = sqsMessages.map { m =>
+      val mintRequest = Json.parse(m.getBody).as[MintRequestSqsMessage]
+      (m, mintRequest)
+    }
+
+    println("Checking if Lambda is running in dry mode")
+
+    val dryMsg =
+      if (config.dry)
+        "Running in dry mode - will not process mint request or attempt to query node"
+      else "NOT Running in dry mode - will attempt to process minting request and query node"
+    println(dryMsg)
+
+    // looping throug the requests and try to mint them
+    val results = mintRequests.map {
+      case (message: SQSEvent.SQSMessage, mintRequest: MintRequestSqsMessage) =>
+        println(s"mint request: $mintRequest")
+        val r = Try(
+          processSqsMessage(
+            sqsClient,
+            message,
+            mintRequest,
+            ergoClient,
+            ergoNodeConfig,
+            mintingContractAddress,
+            config.dry,
+            queueUrl))
+        (mintRequest, r)
+    }
+    val total = results.size
+    val successful = results.map(_._2.isSuccess).size
+    val unsuccess = successful - total
+    println(s"Successful Mints: $successful / $total")
+    println(s"Unsuccessful Mints: $unsuccess / $total ")
+    results.foreach {
+      case (mintRequest: MintRequestSqsMessage, result: Try[String]) =>
+        result match {
+          case Failure(err) =>
+            println(s"Failed processing $mintRequest due to $err")
+          case Success(tx) =>
+            println(s"Succesfully minted $mintRequest tx: $tx")
         }
-
-        println(s"Getting secret $config.secretName from AWS Secrets Manager")
-        val secretString = AwsHelper.getSecretFromSecretsManager(config.secretName, config.awsRegion)
-        println("Parsing secret string into ErgoToolConfig type")
-        val ergoNodeConfig = ErgoToolConfig.load(new StringReader(secretString))
-
-        val networkType = ergoNodeConfig.getNode.getNetworkType
-        println(s"Targeting $networkType")
-
-        // TODO: Update minting method to take an ergoClient rather than a config to instantiate one
-        println(s"Building Ergo client for interacting with node at ${ergoNodeConfig.getNode.getNodeApi.getApiUrl}")
-        val ergoClient = ErgoNamesUtils.buildErgoClient(ergoNodeConfig.getNode, ergoNodeConfig.getNode.getNetworkType)
-
-        val mintingContractAddress =  Address.create(ergoNodeConfig.getParameters.get("mintingContractAddress"))
-        println(s"Minting Contract Address: $mintingContractAddress")
-
-        val queueUrl = config.mintRequestsQueueUrl
-        println(s"Building AWS SQS Client for queue $queueUrl")
-        val sqsClient = getSqsClient(config.awsRegion)
-
-        val sqsMessages = sqsEvent.getRecords.asScala
-        println(s"Pulled ${sqsMessages.length} message(s) from queue")
-        println("Extracting and parsing mint request(s) from SQS message(s)")
-        val mintRequests = sqsMessages.map{ m =>
-          val mintRequest = Json.parse(m.getBody).as[MintRequestSqsMessage]
-          (m, mintRequest)
-        }
-
-        println("Checking if Lambda is running in dry mode")
-   
-        val dryMsg = if (config.dry)  "Running in dry mode - will not process mint request or attempt to query node"
-                     else "NOT Running in dry mode - will attempt to process minting request and query node"
-        println(dryMsg)
-
-        // looping throug the requests and try to mint them
-        val results = mintRequests.map{
-         case (message: SQSEvent.SQSMessage, mintRequest: MintRequestSqsMessage) =>
-            println(s"mint request: $mintRequest")
-            val r = Try(processSqsMessage(sqsClient, message, mintRequest, ergoClient, ergoNodeConfig, mintingContractAddress, config.dry, queueUrl))
-            (mintRequest, r)
-        }
-        val total = results.size
-        val successful = results.map(_._2.isSuccess).size
-        val unsuccess = successful - total
-        println(s"Successful Mints: $successful / $total")
-        println(s"Unsuccessful Mints: $unsuccess / $total ")
-        results.foreach{
-         case (mintRequest :MintRequestSqsMessage, result: Try[String])  =>
-          result match {
-            case Failure(err) =>
-              println(s"Failed processing $mintRequest due to $err")
-            case Success(tx) =>
-              println(s"Succesfully minted $mintRequest tx: $tx")
-          }
-        }
+    }
   }
 }
 
 object ProcessMintingRequest extends Minter {
-  def main(args: Array[String]) : Unit = {
+  def main(args: Array[String]): Unit = {
     val conf: ErgoToolConfig = ErgoToolConfig.load("ergo_node_config.json")
     val networkType = conf.getNode.getNetworkType
     val tokenDesc = conf.getParameters.get("tokenDescription")

--- a/src/main/scala/utils/AwsHelper.scala
+++ b/src/main/scala/utils/AwsHelper.scala
@@ -6,7 +6,8 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest
 object AwsHelper {
 
   def getSecretFromSecretsManager(secretName: String, region: String): String = {
-    val client = AWSSecretsManagerClientBuilder.standard()
+    val client = AWSSecretsManagerClientBuilder
+      .standard()
       .withRegion(region)
       .build()
 

--- a/src/main/scala/utils/ConfigManager.scala
+++ b/src/main/scala/utils/ConfigManager.scala
@@ -2,28 +2,27 @@ package utils
 
 import models.ErgoNamesConfig
 import play.api.libs.json.{Json, Reads}
-import scala.util.{Try,Success,Failure}
+import scala.util.{Try, Success, Failure}
 import java.io.FileNotFoundException
 
 object ConfigManager {
   val pathToConfigFile: String = "config.json"
   implicit val configReads: Reads[ErgoNamesConfig] = Json.reads[ErgoNamesConfig]
 
-  def fromEnv():  Try[ErgoNamesConfig] = {
+  def fromEnv(): Try[ErgoNamesConfig] = {
     Try({
-       val mintRequestsQueueUrl = sys.env.get("mintRequestsQueueUrl").get
-       val dry = sys.env.get("dry").get.toBoolean
-       val secretName = sys.env.get("secretName").get
-       val awsRegion = sys.env.get("awsRegion") match {
-         case Some(r) => r
-         case None => sys.env.get("AWS_REGION").get  
-       }
-       ErgoNamesConfig(mintRequestsQueueUrl, dry, secretName, awsRegion)
-     }
-    )
+      val mintRequestsQueueUrl = sys.env.get("mintRequestsQueueUrl").get
+      val dry = sys.env.get("dry").get.toBoolean
+      val secretName = sys.env.get("secretName").get
+      val awsRegion = sys.env.get("awsRegion") match {
+        case Some(r) => r
+        case None => sys.env.get("AWS_REGION").get
+      }
+      ErgoNamesConfig(mintRequestsQueueUrl, dry, secretName, awsRegion)
+    })
   }
 
-  def fromFile(): Try[ErgoNamesConfig] =  {
+  def fromFile(): Try[ErgoNamesConfig] = {
     Try({
       val content = scala.io.Source.fromFile(pathToConfigFile).mkString
       Json.parse(content).as[ErgoNamesConfig]
@@ -43,4 +42,3 @@ object ConfigManager {
     }
   }
 }
-

--- a/src/test/scala/scenarios/MintLambdaSpec.scala
+++ b/src/test/scala/scenarios/MintLambdaSpec.scala
@@ -4,11 +4,11 @@ import scenarios.ProcessMintingRequest
 import scenarios.ProcessMintingRequest._
 import scenarios.Minter
 
-import org.scalatest.{ PropSpec, Matchers }
+import org.scalatest.{PropSpec, Matchers}
 import org.ergoplatform.ErgoAddressEncoder
 import org.scalatest._
 import org.scalatest.Assertions._
-import org.scalatest.{ Matchers, WordSpecLike }
+import org.scalatest.{Matchers, WordSpecLike}
 import org.scalatest.mockito.MockitoSugar
 
 import org.mockito.Mockito._
@@ -21,13 +21,12 @@ import com.amazonaws.services.lambda.runtime.Context
 
 import play.api.libs.json._
 
-
 import scala.collection.JavaConverters._
 
- class TestableMinter extends Minter
+class TestableMinter extends Minter
 
 class ProcessMintLambdaSpec extends WordSpecLike with Matchers with MockitoSugar {
-/*
+  /*
   "should handle sqs events" in {
 
     // mocking sqs messages

--- a/src/test/scala/scenarios/ScenariosSpec.scala
+++ b/src/test/scala/scenarios/ScenariosSpec.scala
@@ -14,10 +14,10 @@ import org.ergoplatform.ErgoAddressEncoder
 
 import org.scalatest._
 import org.scalatest.Assertions._
-import org.scalatest.{ Matchers, WordSpecLike }
+import org.scalatest.{Matchers, WordSpecLike}
 
 import io.github.dav009.ergopuppet.Simulator._
-import io.github.dav009.ergopuppet.model.{ TokenAmount, TokenInfo }
+import io.github.dav009.ergopuppet.model.{TokenAmount, TokenInfo}
 
 import sigmastate.lang.exceptions.InterpreterException
 
@@ -38,7 +38,8 @@ class SimpleScenarioSpec extends WordSpecLike with Matchers {
     // creates a minting contract address on which requests can be added
     val amountToSpend = Parameters.MinChangeValue + Parameters.MinFee
     val boxes = ergoNames.wallet.getUnspentBoxes(amountToSpend).get
-    val mintingContract = ErgoNamesMintingContract.getContract(ctx, ergoNames.wallet.getAddress.getPublicKey())
+    val mintingContract =
+      ErgoNamesMintingContract.getContract(ctx, ergoNames.wallet.getAddress.getPublicKey())
 
     val mintingContractAddress =
       Address.fromErgoTree(mintingContract.getErgoTree(), NetworkType.TESTNET)
@@ -84,23 +85,14 @@ class SimpleScenarioSpec extends WordSpecLike with Matchers {
       tokenDescription = tokenDesc)
 
     val (goodTx, goodTxArgs) =
-      ProcessMintingRequest.createTx(
-        ctx,
-        ergoNamesUnspentBoxes,
-        ergoNames.wallet.getAddress,
-        mintRequestBox,
-        tokenDesc)
+      ProcessMintingRequest.createTx(ctx, ergoNamesUnspentBoxes, ergoNames.wallet.getAddress, mintRequestBox, tokenDesc)
 
     "entity aside from ergonames should not be able to mint" in {
       val otherBoxes = other.wallet
         .getUnspentBoxes(Parameters.MinFee + Parameters.MinChangeValue + 100000)
         .get
-      val (mintTxshoudFail, _) = ProcessMintingRequest.createTx(
-        ctx,
-        otherBoxes,
-        other.wallet.getAddress,
-        mintRequestBox,
-        tokenDesc)
+      val (mintTxshoudFail, _) = ProcessMintingRequest
+        .createTx(ctx, otherBoxes, other.wallet.getAddress, mintRequestBox, tokenDesc)
       assertThrows[InterpreterException] {
         val signedmintTxshouldFail = other.wallet.sign(mintTxshoudFail)
         ctx.sendTransaction(signedmintTxshouldFail)
@@ -130,9 +122,7 @@ class SimpleScenarioSpec extends WordSpecLike with Matchers {
     "errors if expected payment amount was not received" in {
       val incorrectPaymentToErgoNames = ctx.newTxBuilder.outBoxBuilder
         .value(paymentAmount - 1)
-        .contract(
-          new ErgoTreeContract(
-            ergoNames.wallet.getAddress.getErgoAddress().script))
+        .contract(new ErgoTreeContract(ergoNames.wallet.getAddress.getErgoAddress().script))
         .build()
 
       val badPaymnetTx = ctx.newTxBuilder
@@ -151,8 +141,7 @@ class SimpleScenarioSpec extends WordSpecLike with Matchers {
     "errors if trying to claim the payment box on behalf of ergonames" in {
       val incorrectDestination = ctx.newTxBuilder.outBoxBuilder
         .value(paymentAmount - 1)
-        .contract(
-          new ErgoTreeContract(other.wallet.getAddress.getErgoAddress().script))
+        .contract(new ErgoTreeContract(other.wallet.getAddress.getErgoAddress().script))
         .build()
 
       val badDestinationTx = ctx.newTxBuilder
@@ -172,8 +161,7 @@ class SimpleScenarioSpec extends WordSpecLike with Matchers {
       val badNftOwnerBox = ctx.newTxBuilder.outBoxBuilder
         .mintToken(token, tokenName, tokenDesc, 1)
         .value(Parameters.MinChangeValue)
-        .contract(
-          new ErgoTreeContract(other.wallet.getAddress.getErgoAddress().script))
+        .contract(new ErgoTreeContract(other.wallet.getAddress.getErgoAddress().script))
         .build()
 
       val badNftOwnerTx = ctx.newTxBuilder
@@ -195,7 +183,8 @@ class SimpleScenarioSpec extends WordSpecLike with Matchers {
 
       // assert nft owners
       val customerTokens = blockchainSim.getUnspentTokensFor(customer.wallet.getAddress)
-      val expectedCustomerTokens = List(new TokenAmount(new TokenInfo(mintRequestBox.getId(), tokenName), 1))
+      val expectedCustomerTokens =
+        List(new TokenAmount(new TokenInfo(mintRequestBox.getId(), tokenName), 1))
       assert(customerTokens == expectedCustomerTokens)
 
       // assert ergoname service assets


### PR DESCRIPTION
 I am tired of fighting bad formatting :). 
- including [scalafmt](https://scalameta.org/scalafmt/) 
- reformatting our files using it

to run the formatting do: `sbt scalafmtAll` or [follow the instructions to use it with your IDE](https://scalameta.org/scalafmt/docs/installation.html)