### PR TITLE
Enable and use structured logging in minter service and minting handler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies += "ch.qos.logback.contrib" % "logback-jackson" % "0.1.5"
 libraryDependencies += "ch.qos.logback.contrib" % "logback-json-classic" % "0.1.5"
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.5"
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.25"
+libraryDependencies += "com.github.dwickern" %% "scala-nameof" % "4.0.0" % "provided"
 
 // Java dependencies
 libraryDependencies += "org.mockito" % "mockito-core" % "4.3.1" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,13 @@ libraryDependencies += "io.github.dav009" %% "ergopuppet" % "0.0.0+28-8ee0ca24+2
 libraryDependencies += ("org.scorexfoundation" %% "sigma-state" % "4.0.5" ).classifier("tests")  % Test
 libraryDependencies += "com.lihaoyi" %% "requests" % "0.1.8"
 
+// Dependencies for JSON logging. Do not change versions!
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
+libraryDependencies += "ch.qos.logback.contrib" % "logback-jackson" % "0.1.5"
+libraryDependencies += "ch.qos.logback.contrib" % "logback-json-classic" % "0.1.5"
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.5"
+libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.25"
+
 // Java dependencies
 libraryDependencies += "org.mockito" % "mockito-core" % "4.3.1" % Test
 libraryDependencies += "com.amazonaws" % "aws-java-sdk" % "1.11.46"

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
                 <appendLineSeparator>true</appendLineSeparator>
 
                 <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-                    <prettyPrint>false</prettyPrint>
+                    <prettyPrint>true</prettyPrint>
                 </jsonFormatter>
             </layout>
         </encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <prettyPrint>false</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/src/main/scala/handlers/MintingHandler.scala
+++ b/src/main/scala/handlers/MintingHandler.scala
@@ -5,10 +5,11 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import models.MintingRequestSqsMessage
 import org.ergoplatform.appkit._
 import org.ergoplatform.appkit.config.ErgoToolConfig
-import org.slf4j.LoggerFactory
+import org.slf4j.{LoggerFactory, MDC}
 import play.api.libs.json.{Json, OWrites, Reads}
 import services.Minter
 import utils.{AwsHelper, ErgoNamesUtils}
+import com.github.dwickern.macros.NameOf._
 
 import java.io.StringReader
 import scala.collection.JavaConverters._
@@ -20,55 +21,79 @@ class MintingHandler {
   implicit val mintRequestSqsMessageWrites: OWrites[MintingRequestSqsMessage] = Json.writes[MintingRequestSqsMessage]
 
   def handle(sqsEvent: SQSEvent, context: Context): Unit = {
+    logger.debug("Loading ErgoNames config...")
     val config = ErgoNamesUtils.getConfig
 
-    // TODO: Build logger. Probably using some general utility.
     if (config.awsRegion == null)
       throw new Exception("Did not find 'awsRegion' in environment variables or in local config file")
 
     if (config.secretName == null)
       throw new Exception("Did not find 'secretName' in environment variables or in local config file")
 
+    logger.info("Loading Ergo config from secrets manager")
     val secretString = AwsHelper.getSecretFromSecretsManager(config.secretName, config.awsRegion)
     val ergoConfig = ErgoToolConfig.load(new StringReader(secretString))
+    logger.info("Building Ergo client")
     val ergoClient = ErgoNamesUtils.buildErgoClient(ergoConfig.getNode, ergoConfig.getNode.getNetworkType)
 
     val queueUrl = config.mintRequestsQueueUrl
     if (queueUrl == null)
       throw new Exception("Did not find 'mintRequestsQueue' in environment variables or in local config file")
 
+    logger.debug("Building SQS client")
     val sqsClient = AwsHelper.getSqsClient(config.awsRegion)
+
+    logger.info("Parsing through messages in SQS event payload")
     val sqsMessages = sqsEvent.getRecords.asScala
     val mintRequests = sqsMessages.map{ rawMessage =>
       val parsedMessage = Json.parse(rawMessage.getBody).as[MintingRequestSqsMessage]
       (rawMessage, parsedMessage)
     }
+    logger.info("Finished parsing. Ended up with {} mint request(s)", mintRequests.length)
 
     val dryMsg = if (config.dry)
                     "Running in dry mode - will not process mint request or attempt to query node"
                  else
                     "NOT running in dry mode - will attempt to process minting request and query node"
+    logger.info(dryMsg)
 
+    logger.info("Instantiating new Minter")
     val minter = new Minter(LoggerFactory.getLogger(classOf[Minter]))
-    val txIds = ergoClient.execute((ctx: BlockchainContext) => {
+    logger.info("Initiating blockchain context")
+    val submittedTxIds = ergoClient.execute((ctx: BlockchainContext) => {
+      logger.debug("Building prover")
       val prover = ErgoNamesUtils.buildProver(ctx, ergoConfig.getNode)
+      logger.debug("Building node service")
       val nodeService = ErgoNamesUtils.buildNodeService(ergoConfig)
+      logger.debug("Building wallet service")
       val walletService = ErgoNamesUtils.buildNewWalletApiService(ergoConfig)
 
       val royalty = ergoConfig.getParameters.get("royaltyPercentage").toInt
+      logger.info("Royalty percentage set to {}%", royalty / 10)
       val paymentAddressRaw = ergoConfig.getParameters.get("paymentAddress")
       val paymentAddress = Address.create(paymentAddressRaw)
+      logger.info("Payment collection address set to {}", paymentAddressRaw)
 
+      logger.info("About to start iterating over {} mint request(s)", mintRequests.length)
       mintRequests.map{
         case (rawMessage, mintRequest) =>
           // TODO: Account for failures
-          val txId = minter.mint(mintRequest.mintingRequestBoxId, royalty, ctx, prover, paymentAddress, nodeService, walletService)
+          MDC.put(nameOf(mintRequest.mintingRequestBoxId), mintRequest.mintingRequestBoxId)
+          MDC.put(nameOf(mintRequest.paymentTxId), mintRequest.paymentTxId)
+          logger.info("Attempting to process mint request")
+          val mintTxId = minter.mint(mintRequest.mintingRequestBoxId, royalty, ctx, prover, paymentAddress, nodeService, walletService)
+          MDC.put(nameOf(mintTxId), mintTxId)
+          logger.info("Finished processing mint request")
+          MDC.clear()
+          MDC.put(nameOf(rawMessage.getReceiptHandle), rawMessage.getReceiptHandle)
+          logger.info("Deleting message from queue")
           sqsClient.deleteMessage(queueUrl, rawMessage.getReceiptHandle)
-          txId
+          MDC.clear()
+          mintTxId
       }.toList
     })
 
-    println(s"Finished processing ${mintRequests.length} mint requests.")
-    println(txIds)
+    MDC.put(nameOf(submittedTxIds), submittedTxIds.toString)
+    logger.info(s"Finished processing ${mintRequests.length} mint request(s)")
   }
 }

--- a/src/main/scala/handlers/MintingHandler.scala
+++ b/src/main/scala/handlers/MintingHandler.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import models.MintingRequestSqsMessage
 import org.ergoplatform.appkit._
 import org.ergoplatform.appkit.config.ErgoToolConfig
+import org.slf4j.LoggerFactory
 import play.api.libs.json.{Json, OWrites, Reads}
 import services.Minter
 import utils.{AwsHelper, ErgoNamesUtils}
@@ -13,6 +14,8 @@ import java.io.StringReader
 import scala.collection.JavaConverters._
 
 class MintingHandler {
+  val logger = LoggerFactory.getLogger(getClass)
+
   implicit val mintRequestSqsMessageReads: Reads[MintingRequestSqsMessage] = Json.reads[MintingRequestSqsMessage]
   implicit val mintRequestSqsMessageWrites: OWrites[MintingRequestSqsMessage] = Json.writes[MintingRequestSqsMessage]
 
@@ -46,7 +49,7 @@ class MintingHandler {
                  else
                     "NOT running in dry mode - will attempt to process minting request and query node"
 
-    val minter = new Minter()
+    val minter = new Minter(LoggerFactory.getLogger(classOf[Minter]))
     val txIds = ergoClient.execute((ctx: BlockchainContext) => {
       val prover = ErgoNamesUtils.buildProver(ctx, ergoConfig.getNode)
       val nodeService = ErgoNamesUtils.buildNodeService(ergoConfig)

--- a/src/main/scala/local/LogTest.scala
+++ b/src/main/scala/local/LogTest.scala
@@ -1,0 +1,13 @@
+package local
+
+import org.slf4j.{LoggerFactory, MDC}
+
+object LogTest {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  def main(Args: Array[String]): Unit = {
+    logger.info("This is a JSON formatted log message with no properties")
+//    MDC.put("userId", "123456")
+    logger.info("This is a JSON formatted log message with properties {}{}", 123, 456)
+  }
+}

--- a/src/main/scala/local/ProcessMintingRequest.scala
+++ b/src/main/scala/local/ProcessMintingRequest.scala
@@ -2,23 +2,39 @@ package local
 
 import org.ergoplatform.appkit.{Address, BlockchainContext}
 import org.ergoplatform.appkit.config.ErgoToolConfig
+import org.slf4j.LoggerFactory
 import services.Minter
 import utils.ErgoNamesUtils
 
 object ProcessMintingRequest {
-  def main(args: Array[String]): Unit = {
-    val ergoConfig = ErgoToolConfig.load("ergo_node_config.json")
-    val ergoClient = ErgoNamesUtils.buildErgoClient(ergoConfig.getNode, ergoConfig.getNode.getNetworkType)
-    val nodeService = ErgoNamesUtils.buildNodeService(ergoConfig)
-    val walletService = ErgoNamesUtils.buildNewWalletApiService(ergoConfig)
-    val minter = new Minter()
+  val logger = LoggerFactory.getLogger(getClass)
 
+  def main(args: Array[String]): Unit = {
+    val configFileName = "ergo_node_config.json"
+    logger.debug("Loading {}", configFileName)
+    val ergoConfig = ErgoToolConfig.load(configFileName)
+    logger.debug("Building Ergo Client")
+    val ergoClient = ErgoNamesUtils.buildErgoClient(ergoConfig.getNode, ergoConfig.getNode.getNetworkType)
+    logger.debug("Building Node Service")
+    val nodeService = ErgoNamesUtils.buildNodeService(ergoConfig)
+    logger.debug("Building Wallet Service")
+    val walletService = ErgoNamesUtils.buildNewWalletApiService(ergoConfig)
+    logger.debug("Instantiating new Minter")
+    val minter = new Minter(LoggerFactory.getLogger(classOf[Minter]))
+
+    logger.debug("Initiating blockchain context")
     val txId = ergoClient.execute((ctx: BlockchainContext) => {
+      logger.debug("Building Prover")
       val prover = ErgoNamesUtils.buildProver(ctx, ergoConfig.getNode)
+      logger.debug("Reading mintRequestBox from Ergo Config")
       val mintingRequestBoxId = ergoConfig.getParameters.get("mintRequestBoxId")
+      logger.debug("Reading royaltyPercentage from Ergo Config")
       val royalty = ergoConfig.getParameters.get("royaltyPercentage").toInt
+      logger.debug("Reading paymentAddress from Ergo Config")
       val paymentAddressRaw = ergoConfig.getParameters.get("paymentAddress")
       val paymentAddress = Address.create(paymentAddressRaw)
+
+      logger.debug("Initiating mint")
       minter.mint(mintingRequestBoxId, royalty, ctx, prover, paymentAddress, nodeService, walletService)
     })
 


### PR DESCRIPTION
This is the beginning of adding structured logging to our minter service and the lambda handler that invokes it.

I suspect we will have to go back to this and further tweak/enhance logging to better capture events, specific details about events, and errors in particular, but this is a good first pass.

I'd like to see how the output of these logs look in CloudWatch, so merging what I have into testnet to trigger a lambda deployment.

Should not break anything since it's a bunch of logging changes, but if it does we can revert.